### PR TITLE
Introduce a Dockerfile for fast adoption and isolated build environment.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM golang:1.12.7-alpine3.10 AS local
+
+ARG SRC_DIR=/go/src/github.com/unikraft/tools
+WORKDIR ${SRC_DIR}
+COPY . ${SRC_DIR}
+
+RUN apk --no-cache add \
+      make \
+      git
+
+FROM local AS build
+
+ARG SRC_DIR=/go/src/github.com/unikraft/tools
+
+RUN cd ${SRC_DIR} \
+ && make build
+
+FROM alpine:3.10 AS binary
+
+ARG SRC_DIR=/go/src/github.com/unikraft/tools
+COPY --from=build ${SRC_DIR}/tools /tools
+
+ENTRYPOINT [ "/tools" ]

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,26 @@
-# GO parameters
-GOCMD=go
-GOBUILD=$(GOCMD) build
-GOCLEAN=$(GOCMD) clean
-GOTEST=$(GOCMD) test
-GOGET=$(GOCMD) get
-BINARY_NAME=tools
-BINARY_UNIX=$(BINARY_NAME)_unix
+# Program arguments
+BINARY_NAME    ?= tools
+BINARY_UNIX    ?= $(BINARY_NAME)_unix
+CONTAINER_NAME ?= unikraft/tools:latest
 
+## Tools
+DOCKER   ?= docker
+TARGET   ?= binary
+GO       ?= go
+GOBUILD  ?= $(GO) build
+GOCLEAN  ?= $(GO) clean
+GOTEST   ?= $(GO) test
+GOGET    ?= $(GO) get
+
+# Targets
 all:	build
-
-build:  
+container:
+	$(DOCKER) build \
+		-t $(CONTAINER_NAME) \
+		-f Dockerfile \
+		--target=$(TARGET) \
+		.
+build: deps
 	$(GOBUILD) -o $(BINARY_NAME)  -v
 test:   
 	$(GOTEST) -v ./...

--- a/automatic_build_tool/buildtool.go
+++ b/automatic_build_tool/buildtool.go
@@ -12,8 +12,10 @@ import (
 	"os"
 	"regexp"
 	"strings"
-	"tools/automatic_build_tool/utils_build"
-	u "tools/utils_toolchain"
+
+	u "github.com/unikraft/tools/utils_toolchain"
+
+	"github.com/unikraft/tools/automatic_build_tool/utils_build"
 )
 
 // STATES
@@ -175,8 +177,7 @@ func RunBuildTool(args u.Arguments, data *u.Data, outFolder string) {
 
 	// Generate Config.uk
 	if err := generateConfigUk(appFolder+"Config.uk",
-		strings.ToUpper(programName), matchedLibs);
-		err != nil {
+		strings.ToUpper(programName), matchedLibs); err != nil {
 		u.PrintErr(err)
 	}
 

--- a/automatic_build_tool/utils_build/kconfig_parser.go
+++ b/automatic_build_tool/utils_build/kconfig_parser.go
@@ -11,7 +11,8 @@ import (
 	"io"
 	"os"
 	"strings"
-	u "tools/utils_toolchain"
+
+	u "github.com/unikraft/tools/utils_toolchain"
 )
 
 const (

--- a/automatic_build_tool/utils_build/makefile_process.go
+++ b/automatic_build_tool/utils_build/makefile_process.go
@@ -9,7 +9,8 @@ package utils_build
 import (
 	"path/filepath"
 	"strings"
-	u "tools/utils_toolchain"
+
+	u "github.com/unikraft/tools/utils_toolchain"
 )
 
 // ----------------------------Generate Makefile--------------------------------

--- a/automatic_build_tool/utils_build/microlibs_process.go
+++ b/automatic_build_tool/utils_build/microlibs_process.go
@@ -11,7 +11,8 @@ import (
 	"os"
 	"strings"
 	"sync"
-	u "tools/utils_toolchain"
+
+	u "github.com/unikraft/tools/utils_toolchain"
 )
 
 const (
@@ -84,8 +85,7 @@ func fetchSymbolsExternalLibs(url string,
 			go func(lib, git string, microLibs map[string][]string) {
 				defer wg.Done()
 				u.PrintInfo("Retrieving symbols of external lib: " + lib)
-				if symbols, err := u.DownloadFile(PREFIX_URL + git + SUFFIX_URL);
-					err != nil {
+				if symbols, err := u.DownloadFile(PREFIX_URL + git + SUFFIX_URL); err != nil {
 					u.PrintWarning(err)
 				} else {
 					processSymbols(lib, *symbols, microLibs)

--- a/automatic_build_tool/utils_build/unikraft_files_process.go
+++ b/automatic_build_tool/utils_build/unikraft_files_process.go
@@ -12,7 +12,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	u "tools/utils_toolchain"
+
+	u "github.com/unikraft/tools/utils_toolchain"
 )
 
 // Folder
@@ -139,8 +140,7 @@ func ProcessSourceFiles(sourcesPath, appFolder, includeFolder string,
 			srcLanguages[extension] += 1
 
 			// Copy source files to the appFolder
-			if err = u.CopyFileContents(path, appFolder+info.Name());
-				err != nil {
+			if err = u.CopyFileContents(path, appFolder+info.Name()); err != nil {
 				return err
 			}
 		} else if extension == ".h" {
@@ -148,8 +148,7 @@ func ProcessSourceFiles(sourcesPath, appFolder, includeFolder string,
 			includesFiles = append(includesFiles, info.Name())
 
 			// Copy header files to the INCLUDE_FOLDER
-			if err = u.CopyFileContents(path, includeFolder+info.Name());
-				err != nil {
+			if err = u.CopyFileContents(path, includeFolder+info.Name()); err != nil {
 				return err
 			}
 		} else {

--- a/dependency_analysis_tool/dynamic_analyser.go
+++ b/dependency_analysis_tool/dynamic_analyser.go
@@ -18,8 +18,10 @@ import (
 	"strings"
 	"syscall"
 	"time"
-	"tools/dependency_analysis_tool/utils_dependency"
-	u "tools/utils_toolchain"
+
+	u "github.com/unikraft/tools/utils_toolchain"
+
+	"github.com/unikraft/tools/dependency_analysis_tool/utils_dependency"
 )
 
 type DynamicArgs struct {

--- a/dependency_analysis_tool/static_analyser.go
+++ b/dependency_analysis_tool/static_analyser.go
@@ -10,8 +10,10 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"tools/dependency_analysis_tool/utils_dependency"
-	u "tools/utils_toolchain"
+
+	u "github.com/unikraft/tools/utils_toolchain"
+
+	"github.com/unikraft/tools/dependency_analysis_tool/utils_dependency"
 )
 
 // ---------------------------------Gather Data---------------------------------

--- a/dependency_analysis_tool/utils_dependency/graph_process.go
+++ b/dependency_analysis_tool/utils_dependency/graph_process.go
@@ -7,10 +7,12 @@
 package utils_dependency
 
 import (
-	"github.com/awalterschulze/gographviz"
 	"math/rand"
 	"os"
-	"tools/utils_toolchain"
+
+	util_tools "github.com/unikraft/tools/utils_toolchain"
+
+	"github.com/awalterschulze/gographviz"
 )
 
 const letterBytes = "0123456789ABCDEF"
@@ -39,7 +41,7 @@ func ColorGenerator() string {
 // It returns a graph which represents all the direct and no-direct dependencies
 // of a given application and an error if any, otherwise it returns nil.
 func CreateGraph(programName string, data map[string][]string) (*gographviz.
-Escape, error) {
+	Escape, error) {
 	graph := gographviz.NewEscape()
 
 	if err := graph.SetName(programName); err != nil {

--- a/dependency_analysis_tool/utils_dependency/parser.go
+++ b/dependency_analysis_tool/utils_dependency/parser.go
@@ -10,7 +10,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-	"tools/utils_toolchain"
+
+	util_tools "github.com/unikraft/tools/utils_toolchain"
 )
 
 type RecursiveData struct {

--- a/main.go
+++ b/main.go
@@ -8,16 +8,17 @@ package main
 
 import (
 	"fmt"
-	"github.com/fatih/color"
 	"os"
 	"os/user"
 	"runtime"
 	"strconv"
 	"strings"
-	build "tools/automatic_build_tool"
-	dep "tools/dependency_analysis_tool"
-	"tools/dependency_analysis_tool/utils_dependency"
-	u "tools/utils_toolchain"
+
+	"github.com/fatih/color"
+	build "github.com/unikraft/tools/automatic_build_tool"
+	dep "github.com/unikraft/tools/dependency_analysis_tool"
+	"github.com/unikraft/tools/dependency_analysis_tool/utils_dependency"
+	u "github.com/unikraft/tools/utils_toolchain"
 )
 
 const OUT_FOLDER = "output/"


### PR DESCRIPTION
In this commit I add a Dockerfile and new Makefile target, `make container`, that builds the container with the container name `unikraft/tools:latest`.  In addition to this, I had to update the namespace of the three packages within the repository to include the full path the git repository, e.g.:

    tools/utils_toolchain -> github.com/unikraft/tools/utils_toolchain

I did so as the repository itself appears to be hosted primarily on Github as opposed to Xenbits.  This also follows good Go practices in aim of distributing code.

The Dockerfile itself has been split into three seperate builds, `local`, `build` and `binary` that serve as seperate environments for developing unikraft/unicore tools program; building the binary and for distribtion of the binary, respectively.